### PR TITLE
feat: add auth user endpoint

### DIFF
--- a/api/auth/user.ts
+++ b/api/auth/user.ts
@@ -1,0 +1,26 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export const config = { runtime: 'edge' };
+
+export default async function handler(req: Request) {
+  const cookieStore = cookies();
+
+  const supabase = createServerClient(
+    process.env.SUPABASE_URL!,
+    process.env.SERVICE_ROLE_KEY!,
+    { cookies: cookieStore }
+  );
+
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  return new Response(JSON.stringify(user), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+}


### PR DESCRIPTION
## Summary
- add `/api/auth/user` edge endpoint to fetch the authenticated Supabase user

## Testing
- `npm test --prefix client` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab8f3706008330aabcd0c87f9e0e5b