### PR TITLE
feat: add supabase login and navigation link

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import Questionnaire from "@/pages/questionnaire";
 import Crowdfunding from "@/pages/crowdfunding";
 import Profile from "@/pages/profile-working";
 import ProfileEdit from "@/pages/profile-edit";
+import Login from "@/pages/login";
 
 import Operations from "@/pages/operations";
 import Ownership from "@/pages/ownership";
@@ -38,6 +39,7 @@ function Router() {
       <Route path="/forum/ownership" component={Ownership} />
       <Route path="/profile/:id" component={Profile} />
       <Route path="/profile/:id/edit" component={ProfileEdit} />
+      <Route path="/login" component={Login} />
 
       {/* 👇 add a temporary route for testing Supabase */}
       <Route path="/auth-test" component={AuthTest} />

--- a/client/src/components/layout/navigation.tsx
+++ b/client/src/components/layout/navigation.tsx
@@ -131,13 +131,14 @@ export default function Navigation() {
               </div>
               <h3 className="font-semibold text-white mb-2">Join Village-One</h3>
               <p className="text-xs text-gray-400 mb-3">Connect with builders creating a sustainable future</p>
-              <Button 
-                className="w-full bg-gradient-to-r from-holo-gold to-electric-green text-space font-semibold py-2 px-4 rounded-lg hover:scale-105 transition-transform duration-300 text-sm"
-                onClick={() => window.location.href = '/api/login'}
-                data-testid="button-join-community"
-              >
-                Create Account
-              </Button>
+              <Link href="/login">
+                <Button
+                  className="w-full bg-gradient-to-r from-holo-gold to-electric-green text-space font-semibold py-2 px-4 rounded-lg hover:scale-105 transition-transform duration-300 text-sm"
+                  data-testid="button-join-community"
+                >
+                  Create Account
+                </Button>
+              </Link>
             </div>
           )}
         </div>
@@ -214,14 +215,15 @@ export default function Navigation() {
               <span>Logout</span>
             </Button>
           ) : (
-            <Button
-              className="w-full flex items-center justify-center space-x-2 bg-gradient-to-r from-holo-gold to-electric-green text-space font-semibold py-3 rounded-lg hover:scale-105 transition-transform duration-300"
-              onClick={() => window.location.href = '/api/login'}
-              data-testid="button-login"
-            >
-              <LogIn size={16} />
-              <span>Login</span>
-            </Button>
+            <Link href="/login">
+              <Button
+                className="w-full flex items-center justify-center space-x-2 bg-gradient-to-r from-holo-gold to-electric-green text-space font-semibold py-3 rounded-lg hover:scale-105 transition-transform duration-300"
+                data-testid="button-login"
+              >
+                <LogIn size={16} />
+                <span>Login</span>
+              </Button>
+            </Link>
           )}
           
           <Button 

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { supabase } from "@/lib/supabaseClient";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useLocation } from "wouter";
+
+export default function Login() {
+  const [, setLocation] = useLocation();
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
+  const [form, setForm] = useState({ email: "", password: "" });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const { email, password } = form;
+    const { error: authError } =
+      mode === "signin"
+        ? await supabase.auth.signInWithPassword({ email, password })
+        : await supabase.auth.signUp({ email, password });
+    setLoading(false);
+    if (authError) {
+      setError(authError.message);
+    } else {
+      setLocation("/");
+    }
+  };
+
+  const signInOAuth = async (provider: "google" | "github") => {
+    await supabase.auth.signInWithOAuth({ provider });
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-space">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 p-6 card-rare rounded-lg bg-gradient-to-br from-void to-purple-deep text-white"
+      >
+        <h2 className="text-xl font-semibold text-center">
+          {mode === "signin" ? "Sign In" : "Sign Up"}
+        </h2>
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={form.email}
+            onChange={(e) => setForm({ ...form, email: e.target.value })}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={form.password}
+            onChange={(e) => setForm({ ...form, password: e.target.value })}
+            required
+          />
+        </div>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? "Loading..." : mode === "signin" ? "Sign In" : "Sign Up"}
+        </Button>
+        <div className="flex justify-center">
+          <button
+            type="button"
+            className="text-xs text-neon-cyan"
+            onClick={() => setMode(mode === "signin" ? "signup" : "signin")}
+          >
+            {mode === "signin"
+              ? "Need an account? Sign up"
+              : "Have an account? Sign in"}
+          </button>
+        </div>
+        <div className="space-y-2 pt-4">
+          <Button
+            type="button"
+            className="w-full"
+            onClick={() => signInOAuth("google")}
+          >
+            Continue with Google
+          </Button>
+          <Button
+            type="button"
+            className="w-full"
+            onClick={() => signInOAuth("github")}
+          >
+            Continue with GitHub
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add login page for email/password auth and OAuth providers
- use internal routing for login links in navigation
- wire login route into app router

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: see TypeScript errors in client/src components)*

------
https://chatgpt.com/codex/tasks/task_e_68abd07e2e988330bfa9f3a7dba65226