### PR TITLE
Add Supabase login and signup components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import Questionnaire from "@/pages/questionnaire";
 import Crowdfunding from "@/pages/crowdfunding";
 import Profile from "@/pages/profile-working";
 import ProfileEdit from "@/pages/profile-edit";
+import LoginPage from "@/pages/login";
 
 import Operations from "@/pages/operations";
 import Ownership from "@/pages/ownership";
@@ -31,6 +32,7 @@ function Router() {
       <Route path="/forum/:section" component={Forum} />
       <Route path="/post/:id" component={PostPage} />
       <Route path="/people" component={People} />
+      <Route path="/login" component={LoginPage} />
 
       <Route path="/questionnaire" component={Questionnaire} />
       <Route path="/crowdfunding" component={Crowdfunding} />

--- a/client/src/components/forms/login-form.tsx
+++ b/client/src/components/forms/login-form.tsx
@@ -1,0 +1,73 @@
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { supabase } from "@/lib/supabaseClient";
+import { useToast } from "@/hooks/use-toast";
+import { useLocation } from "wouter";
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export type LoginFormValues = z.infer<typeof schema>;
+
+export default function LoginForm() {
+  const { toast } = useToast();
+  const [, navigate] = useLocation();
+
+  const form = useForm<LoginFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: "", password: "" },
+  });
+
+  const onSubmit = async (values: LoginFormValues) => {
+    const { error } = await supabase.auth.signInWithPassword({
+      email: values.email,
+      password: values.password,
+    });
+
+    if (error) {
+      toast({ title: "Login failed", description: error.message, variant: "destructive" });
+    } else {
+      navigate("/");
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="you@example.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Password</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full">Log In</Button>
+      </form>
+    </Form>
+  );
+}

--- a/client/src/components/forms/signup-form.tsx
+++ b/client/src/components/forms/signup-form.tsx
@@ -1,0 +1,74 @@
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { supabase } from "@/lib/supabaseClient";
+import { useToast } from "@/hooks/use-toast";
+import { useLocation } from "wouter";
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export type SignupFormValues = z.infer<typeof schema>;
+
+export default function SignupForm() {
+  const { toast } = useToast();
+  const [, navigate] = useLocation();
+
+  const form = useForm<SignupFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: "", password: "" },
+  });
+
+  const onSubmit = async (values: SignupFormValues) => {
+    const { data, error } = await supabase.auth.signUp({
+      email: values.email,
+      password: values.password,
+    });
+
+    if (error) {
+      toast({ title: "Sign up failed", description: error.message, variant: "destructive" });
+    } else {
+      const id = data.user?.id;
+      navigate(id ? `/profile/${id}` : "/");
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="you@example.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Password</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full">Sign Up</Button>
+      </form>
+    </Form>
+  );
+}

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import LoginForm from "@/components/forms/login-form";
+import SignupForm from "@/components/forms/signup-form";
+import { Button } from "@/components/ui/button";
+
+export default function LoginPage() {
+  const [mode, setMode] = useState<"login" | "signup">("login");
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-4">
+        {mode === "login" ? (
+          <>
+            <h2 className="text-center text-xl font-semibold">Log In</h2>
+            <LoginForm />
+            <p className="text-center text-sm">
+              Don't have an account?{" "}
+              <Button variant="link" onClick={() => setMode("signup")}>Sign up</Button>
+            </p>
+          </>
+        ) : (
+          <>
+            <h2 className="text-center text-xl font-semibold">Sign Up</h2>
+            <SignupForm />
+            <p className="text-center text-sm">
+              Already have an account?{" "}
+              <Button variant="link" onClick={() => setMode("login")}>Log in</Button>
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Supabase-based login and signup forms
- add login page to show sign in or sign up
- wire `/login` route

## Testing
- `npm --prefix client run check` *(fails: Property 'updatedAt' does not exist on type 'Post', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68abd08c740c8330badcef5d74ea1e04