### PR TITLE
refactor: derive cookie header from request

### DIFF
--- a/api/auth/user.ts
+++ b/api/auth/user.ts
@@ -1,15 +1,12 @@
 import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
 
 export const config = { runtime: 'edge' };
 
 export default async function handler(req: Request) {
-  const cookieStore = cookies();
-
   const supabase = createServerClient(
     process.env.SUPABASE_URL!,
     process.env.SERVICE_ROLE_KEY!,
-    { cookies: cookieStore }
+    { cookies: { get: () => req.headers.get('cookie') } }
   );
 
   const {
@@ -17,7 +14,7 @@ export default async function handler(req: Request) {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    return new Response('Unauthorized', { status: 401 });
+    return new Response(null, { status: 401 });
   }
 
   return new Response(JSON.stringify(user), {


### PR DESCRIPTION
## Summary
- derive cookie header from `Request` for Supabase auth
- return 401 when user absent and user JSON otherwise

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm --prefix client run check` *(fails: tsc compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abd0a728048330985914de26722a5d