### PR TITLE
Add OAuth redirect handling for Supabase login

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -30,7 +30,10 @@ export default function Login() {
   };
 
   const signInOAuth = async (provider: "google" | "github") => {
-    await supabase.auth.signInWithOAuth({ provider });
+    await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: window.location.origin },
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure Supabase OAuth login redirects back to the current origin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Property 'content' does not exist on type 'Post', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abec7eded083308f3c2bf03ae26cbd