### PR TITLE
Expose profile in auth context and consume in navigation

### DIFF
--- a/client/src/components/layout/navigation.tsx
+++ b/client/src/components/layout/navigation.tsx
@@ -38,14 +38,21 @@ const FORUM_SECTIONS = [
 export default function Navigation() {
   const [location] = useLocation();
   const [chatOpen, setChatOpen] = useState(false);
-  const { user, isAuthenticated, signOut } = useAuth() as { user: { id: string; username?: string; email?: string; archetype?: string; level?: number; contributions?: number; profileImageUrl?: string } | null, isAuthenticated: boolean, signOut: () => Promise<void> };
+  const { user, profile, isAuthenticated, signOut } = useAuth();
 
   const currentUser = isAuthenticated && user ? {
-    name: (user as any).username || (user as any).email?.split('@')[0] || 'User',
-    archetype: (user as any).archetype || 'Village Builder',
-    level: (user as any).level || 1,
-    contributions: (user as any).contributions || 0,
-    avatar: (user as any).profileImageUrl || "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=80&h=80"
+    name:
+      (profile as any)?.username ||
+      (profile as any)?.displayName ||
+      user.email?.split("@")[0] ||
+      "User",
+    archetype: (profile as any)?.archetype || "Village Builder",
+    level: (profile as any)?.level || 1,
+    contributions: (profile as any)?.contributions || 0,
+    avatar:
+      (profile as any)?.profileImageUrl ||
+      (profile as any)?.avatarUrl ||
+      "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=80&h=80",
   } : null;
 
   return (

--- a/client/src/hooks/useAuth.tsx
+++ b/client/src/hooks/useAuth.tsx
@@ -1,9 +1,11 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabaseClient";
+import type { Profile } from "@shared/types";
 
 interface AuthContextValue {
   user: User | null;
+  profile: Profile | null;
   session: Session | null;
   isLoading: boolean;
   signIn: (email: string, password: string) => Promise<{ user: User | null; session: Session | null }>;
@@ -16,6 +18,7 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -32,6 +35,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       listener.subscription.unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setProfile(null);
+      return;
+    }
+
+    supabase
+      .from("profiles")
+      .select("*")
+      .eq("id", user.id)
+      .single()
+      .then(({ data, error }) => {
+        if (error) {
+          console.error("Error fetching profile", error);
+          setProfile(null);
+          return;
+        }
+        setProfile(data as Profile);
+      });
+  }, [user]);
 
   const signIn = async (email: string, password: string) => {
     const { data, error } = await supabase.auth.signInWithPassword({ email, password });
@@ -50,7 +74,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, isLoading, signIn, signUp, signOut }}>
+    <AuthContext.Provider value={{ user, profile, session, isLoading, signIn, signUp, signOut }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- fetch profile data from Supabase whenever the auth user changes and expose it from the auth context
- update navigation to use the loaded profile details instead of casting the auth user object

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors: Property 'updatedAt' does not exist on type 'Post', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abf275424c8330ad0dcd2fe8b924f4