### PR TITLE
Use Supabase auth for user endpoints

### DIFF
--- a/api/users/[id]/certificates.ts
+++ b/api/users/[id]/certificates.ts
@@ -1,17 +1,33 @@
-import { supabase } from '../../lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl =
+  process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  '';
 
 // GET /api/users/:id/certificates
 export default async function handler(req: any, res: any) {
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: req.headers.authorization || '' } },
+  });
+
   const { id } = req.query || {};
   const rawId = Array.isArray(id) ? id[0] : id;
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    if (error || !user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    userId = sessionUser.id;
+    userId = user.id;
   }
 
   const { data: profile } = await supabase

--- a/api/users/[id]/degrees.ts
+++ b/api/users/[id]/degrees.ts
@@ -1,17 +1,33 @@
-import { supabase } from '../../lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl =
+  process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  '';
 
 // GET /api/users/:id/degrees
 export default async function handler(req: any, res: any) {
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: req.headers.authorization || '' } },
+  });
+
   const { id } = req.query || {};
   const rawId = Array.isArray(id) ? id[0] : id;
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    if (error || !user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    userId = sessionUser.id;
+    userId = user.id;
   }
 
   const { data: profile } = await supabase

--- a/api/users/[id]/gallery.ts
+++ b/api/users/[id]/gallery.ts
@@ -1,17 +1,33 @@
-import { supabase } from '../../lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl =
+  process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  '';
 
 // GET /api/users/:id/gallery
 export default async function handler(req: any, res: any) {
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: req.headers.authorization || '' } },
+  });
+
   const { id } = req.query || {};
   const rawId = Array.isArray(id) ? id[0] : id;
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    if (error || !user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    userId = sessionUser.id;
+    userId = user.id;
   }
 
   const { data: profile } = await supabase

--- a/api/users/[id]/index.ts
+++ b/api/users/[id]/index.ts
@@ -1,17 +1,33 @@
-import { supabase } from '../../lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl =
+  process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  '';
 
 // Handler for GET /api/users/:id or /api/users/me
 export default async function handler(req: any, res: any) {
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: req.headers.authorization || '' } },
+  });
+
   const { id } = req.query || {};
   const rawId = Array.isArray(id) ? id[0] : id;
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    if (error || !user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    userId = sessionUser.id;
+    userId = user.id;
   }
 
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- use per-request Supabase client instead of session data
- fetch current user via `supabase.auth.getUser()` for `/api/users/me`
- handle missing user with 401 responses

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test --prefix client` *(fails: Missing script "test")*
- `npm run check --prefix client` *(fails: Property 'updatedAt' does not exist on type 'Post')*


------
https://chatgpt.com/codex/tasks/task_e_68aca393bb908330b70b4ec824525630