### PR TITLE
feat: add users api endpoint

### DIFF
--- a/api/users/index.ts
+++ b/api/users/index.ts
@@ -1,0 +1,18 @@
+import { supabase } from '../lib/supabase';
+
+// GET /api/users - return list of user profiles
+export default async function handler(req: any, res: any) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, username, archetype, level');
+
+  if (error) {
+    return res.status(500).json({ error: error.message });
+  }
+
+  return res.status(200).json(data || []);
+}


### PR DESCRIPTION
## Summary
- add `/api/users` endpoint to fetch user profiles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca33d32f883308c0d5581c77440e6