### PR TITLE
Use Supabase auth and enforce env vars

### DIFF
--- a/api/lib/supabase.ts
+++ b/api/lib/supabase.ts
@@ -1,6 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY || '';
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('Missing environment variable: SUPABASE_URL');
+}
+
+if (!supabaseKey) {
+  throw new Error('Missing environment variable: SUPABASE_SERVICE_ROLE_KEY');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/api/users/[id]/certificates.ts
+++ b/api/users/[id]/certificates.ts
@@ -7,11 +7,20 @@ export default async function handler(req: any, res: any) {
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
+    const authHeader = req.headers?.authorization;
+    const token = authHeader?.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : authHeader;
+
+    const { data: userData, error: userError } = await supabase.auth.getUser(
+      token
+    );
+
+    if (userError || !userData.user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    userId = sessionUser.id;
+
+    userId = userData.user.id;
   }
 
   const { data: profile } = await supabase

--- a/api/users/[id]/degrees.ts
+++ b/api/users/[id]/degrees.ts
@@ -7,11 +7,20 @@ export default async function handler(req: any, res: any) {
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
+    const authHeader = req.headers?.authorization;
+    const token = authHeader?.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : authHeader;
+
+    const { data: userData, error: userError } = await supabase.auth.getUser(
+      token
+    );
+
+    if (userError || !userData.user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    userId = sessionUser.id;
+
+    userId = userData.user.id;
   }
 
   const { data: profile } = await supabase

--- a/api/users/[id]/gallery.ts
+++ b/api/users/[id]/gallery.ts
@@ -7,11 +7,20 @@ export default async function handler(req: any, res: any) {
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
+    const authHeader = req.headers?.authorization;
+    const token = authHeader?.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : authHeader;
+
+    const { data: userData, error: userError } = await supabase.auth.getUser(
+      token
+    );
+
+    if (userError || !userData.user) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
-    userId = sessionUser.id;
+
+    userId = userData.user.id;
   }
 
   const { data: profile } = await supabase


### PR DESCRIPTION
## Summary
- Require SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in API supabase client
- Use `supabase.auth.getUser()` instead of `req.session` for user endpoints

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd client && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acacb2d3dc8330aa097a77b1259a90