### PR TITLE
Handle profile query errors in user endpoints

### DIFF
--- a/api/posts/user.ts
+++ b/api/posts/user.ts
@@ -22,11 +22,15 @@ export default async function handler(req: any, res: any) {
     userId = sessionUser.id;
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', userId)
     .single();
+
+  if (profileError) {
+    return res.status(500).json({ error: profileError.message });
+  }
 
   if (!profile) {
     return res.status(404).json({ error: 'User not found' });

--- a/api/users/[id]/certificates.ts
+++ b/api/users/[id]/certificates.ts
@@ -14,11 +14,15 @@ export default async function handler(req: any, res: any) {
     userId = sessionUser.id;
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', userId)
     .single();
+
+  if (profileError) {
+    return res.status(500).json({ error: profileError.message });
+  }
 
   if (!profile) {
     return res.status(404).json({ error: 'User not found' });

--- a/api/users/[id]/degrees.ts
+++ b/api/users/[id]/degrees.ts
@@ -14,11 +14,15 @@ export default async function handler(req: any, res: any) {
     userId = sessionUser.id;
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', userId)
     .single();
+
+  if (profileError) {
+    return res.status(500).json({ error: profileError.message });
+  }
 
   if (!profile) {
     return res.status(404).json({ error: 'User not found' });

--- a/api/users/[id]/gallery.ts
+++ b/api/users/[id]/gallery.ts
@@ -14,11 +14,15 @@ export default async function handler(req: any, res: any) {
     userId = sessionUser.id;
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', userId)
     .single();
+
+  if (profileError) {
+    return res.status(500).json({ error: profileError.message });
+  }
 
   if (!profile) {
     return res.status(404).json({ error: 'User not found' });

--- a/api/users/[id]/index.ts
+++ b/api/users/[id]/index.ts
@@ -23,17 +23,21 @@ export default async function handler(req: any, res: any) {
       userId = sessionUser.id;
     }
 
-    const { data, error } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .select('*')
       .eq('id', userId)
       .single();
 
-    if (error || !data) {
+    if (profileError) {
+      return res.status(500).json({ error: profileError.message });
+    }
+
+    if (!profile) {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    return res.status(200).json(data);
+    return res.status(200).json(profile);
   }
 
   if (req.method === 'PATCH') {
@@ -59,18 +63,22 @@ export default async function handler(req: any, res: any) {
     if (typeof profileImageUrl === 'string')
       updates.profileImageUrl = profileImageUrl;
 
-    const { data, error } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .update(updates)
       .eq('id', userData.user.id)
       .select()
       .single();
 
-    if (error || !data) {
-      return res.status(500).json({ error: error?.message || 'Update failed' });
+    if (profileError) {
+      return res.status(500).json({ error: profileError.message });
     }
 
-    return res.status(200).json(data);
+    if (!profile) {
+      return res.status(500).json({ error: 'Update failed' });
+    }
+
+    return res.status(200).json(profile);
   }
 
   return res.status(405).json({ error: 'Method not allowed' });

--- a/api/users/index.ts
+++ b/api/users/index.ts
@@ -6,13 +6,13 @@ export default async function handler(req: any, res: any) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { data, error } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id, username, archetype, level');
 
-  if (error) {
-    return res.status(500).json({ error: error.message });
+  if (profileError) {
+    return res.status(500).json({ error: profileError.message });
   }
 
-  return res.status(200).json(data || []);
+  return res.status(200).json(profile || []);
 }


### PR DESCRIPTION
## Summary
- capture profile and profileError from `profiles` queries across user-related API endpoints
- return 500 responses when profileError is present

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acacbc8a0c8330ac6489001d49d40b