### PR TITLE
feat: add updatedAt timestamp to Post type

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -18,6 +18,7 @@ export interface Post {
   title: string;
   body: string | null;
   created_at: string;         // ISO timestamp
+  updatedAt?: string;         // ISO timestamp of last update
 }
 
 /** Convenience shapes */


### PR DESCRIPTION
## Summary
- add optional updatedAt field to Post interface for tracking last update

## Testing
- `npm run check --prefix client` *(fails: Property 'content' does not exist on type 'Post', Cannot find module 'drizzle-orm/pg-core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68acacbdf56883308d9dd4a45cb8a6e3