### PR TITLE
Use per-request Supabase client for user media endpoints

### DIFF
--- a/api/users/[id]/certificates.ts
+++ b/api/users/[id]/certificates.ts
@@ -1,27 +1,45 @@
-import { supabase } from '../../lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL!;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 // GET /api/users/:id/certificates
 export default async function handler(req: any, res: any) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method Not Allowed' });
   }
+
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: req.headers.authorization || '' } },
+  });
+
+  const authHeader = req.headers?.authorization;
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : authHeader;
+
   const { id } = req.query || {};
   const rawId = Array.isArray(id) ? id[0] : id;
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
-      return res.status(401).json({ error: 'Unauthorized' });
+    const { data: userData, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !userData?.user) {
+      return res.status(401).json({ error: authError?.message || 'Unauthorized' });
     }
-    userId = sessionUser.id;
+    userId = userData.user.id;
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', userId)
     .single();
+
+  if (profileError) {
+    return res.status(500).json({ error: profileError.message });
+  }
 
   if (!profile) {
     return res.status(404).json({ error: 'User not found' });

--- a/api/users/[id]/degrees.ts
+++ b/api/users/[id]/degrees.ts
@@ -1,27 +1,45 @@
-import { supabase } from '../../lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL!;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 // GET /api/users/:id/degrees
 export default async function handler(req: any, res: any) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method Not Allowed' });
   }
+
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: req.headers.authorization || '' } },
+  });
+
+  const authHeader = req.headers?.authorization;
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : authHeader;
+
   const { id } = req.query || {};
   const rawId = Array.isArray(id) ? id[0] : id;
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
-      return res.status(401).json({ error: 'Unauthorized' });
+    const { data: userData, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !userData?.user) {
+      return res.status(401).json({ error: authError?.message || 'Unauthorized' });
     }
-    userId = sessionUser.id;
+    userId = userData.user.id;
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', userId)
     .single();
+
+  if (profileError) {
+    return res.status(500).json({ error: profileError.message });
+  }
 
   if (!profile) {
     return res.status(404).json({ error: 'User not found' });

--- a/api/users/[id]/gallery.ts
+++ b/api/users/[id]/gallery.ts
@@ -1,27 +1,45 @@
-import { supabase } from '../../lib/supabase';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL!;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 // GET /api/users/:id/gallery
 export default async function handler(req: any, res: any) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method Not Allowed' });
   }
+
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    global: { headers: { Authorization: req.headers.authorization || '' } },
+  });
+
+  const authHeader = req.headers?.authorization;
+  const token = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : authHeader;
+
   const { id } = req.query || {};
   const rawId = Array.isArray(id) ? id[0] : id;
 
   let userId = rawId;
   if (rawId === 'me') {
-    const sessionUser = req.session?.user || req.user;
-    if (!sessionUser?.id) {
-      return res.status(401).json({ error: 'Unauthorized' });
+    const { data: userData, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !userData?.user) {
+      return res.status(401).json({ error: authError?.message || 'Unauthorized' });
     }
-    userId = sessionUser.id;
+    userId = userData.user.id;
   }
 
-  const { data: profile } = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from('profiles')
     .select('id')
     .eq('id', userId)
     .single();
+
+  if (profileError) {
+    return res.status(500).json({ error: profileError.message });
+  }
 
   if (!profile) {
     return res.status(404).json({ error: 'User not found' });


### PR DESCRIPTION
## Summary
- create per-request Supabase client in user `certificates`, `degrees`, and `gallery` endpoints
- verify `me` requests with `supabase.auth.getUser` and forward Authorization header
- add profile lookup error handling before querying user data tables

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Village_One/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68accdbc17e08330bfa68cf7a9ff052f