### PR TITLE
refactor: align profile naming

### DIFF
--- a/client/src/components/layout/navigation.tsx
+++ b/client/src/components/layout/navigation.tsx
@@ -41,17 +41,12 @@ export default function Navigation() {
   const { user, profile, isAuthenticated, signOut } = useAuth();
 
   const currentUser = isAuthenticated && user ? {
-    name:
-      (profile as any)?.username ||
-      (profile as any)?.displayName ||
-      user.email?.split("@")[0] ||
-      "User",
-    archetype: (profile as any)?.archetype || "Village Builder",
-    level: (profile as any)?.level || 1,
-    contributions: (profile as any)?.contributions || 0,
+    name: profile?.displayName || user.email?.split("@")[0] || "User",
+    archetype: "Village Builder",
+    level: 1,
+    contributions: 0,
     avatar:
-      (profile as any)?.profileImageUrl ||
-      (profile as any)?.avatarUrl ||
+      profile?.avatarUrl ||
       "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=80&h=80",
   } : null;
 

--- a/client/src/hooks/useAuth.tsx
+++ b/client/src/hooks/useAuth.tsx
@@ -71,7 +71,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     supabase
       .from("profiles")
-      .select("*")
+      .select("id, display_name, avatar_url, created_at")
       .eq("id", user.id)
       .single()
       .then(({ data, error }) => {
@@ -80,7 +80,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           setProfile(null);
           return;
         }
-        setProfile(data as Profile);
+        if (data) {
+          const mapped: Profile = {
+            id: data.id,
+            displayName: data.display_name,
+            avatarUrl: data.avatar_url,
+            createdAt: data.created_at,
+          };
+          setProfile(mapped);
+        }
       });
   }, [user]);
 

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -80,7 +80,7 @@ export default function Profile() {
   });
 
   const { data: userPosts, isLoading: postsLoading } = useQuery({
-    queryKey: ['/api/posts/user', userId === 'me' && currentUser ? (currentUser as any).id : userId],
+    queryKey: ['/api/posts/user', userId === 'me' && currentUser ? currentUser.id : userId],
     enabled: !!userId,
   });
 
@@ -100,7 +100,7 @@ export default function Profile() {
   });
 
   // Check if viewing own profile
-  const isOwnProfile = isAuthenticated && (userId === 'me' || (userId === (currentUser as any)?.id));
+  const isOwnProfile = isAuthenticated && (userId === 'me' || userId === currentUser?.id);
 
   const { data: userDrafts } = useQuery({
     queryKey: ['/api/users/me/drafts'],

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -6,9 +6,9 @@ export type UserId = string;
 /** profiles table */
 export interface Profile {
   id: UserId;                 // PK, auth.users.id
-  display_name: string | null;
-  avatar_url: string | null;
-  created_at: string;         // ISO timestamp
+  displayName: string | null;
+  avatarUrl: string | null;
+  createdAt: string;         // ISO timestamp
 }
 
 /** posts table */


### PR DESCRIPTION
## Summary
- use camelCase for profile properties across shared types
- map Supabase profile rows to camelCase in auth hook
- consume typed profile data in navigation without any casts

## Testing
- `npm run check` *(fails: Property 'content' does not exist on type 'Post'; ... Cannot find module 'drizzle-orm/pg-core')*

------
https://chatgpt.com/codex/tasks/task_e_68acd3f44a648330ad4cf4fbf74b4ef2